### PR TITLE
Name change for pseudoFirstOrder Enhancement factor

### DIFF
--- a/src/enhancementModels/Make/files
+++ b/src/enhancementModels/Make/files
@@ -3,6 +3,6 @@ enhancementModel/enhancementModelNew.C
 
 noEnhancement/noEnhancement.C
 lowHa/lowHa.C
-pseudoFirstOrder/pseudoFirstOrder.C
+surfaceRenewalPseudoFirstOrder/surfaceRenewalPseudoFirstOrder.C
 
 LIB = $(FOAM_USER_LIBBIN)/libenhancementModels

--- a/src/enhancementModels/surfaceRenewalPseudoFirstOrder/surfaceRenewalPseudoFirstOrder.C
+++ b/src/enhancementModels/surfaceRenewalPseudoFirstOrder/surfaceRenewalPseudoFirstOrder.C
@@ -25,7 +25,7 @@ License
 
 \*---------------------------------------------------------------------------*/
 
-#include "pseudoFirstOrder.H"
+#include "surfaceRenewalPseudoFirstOrder.H"
 #include "addToRunTimeSelectionTable.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
@@ -34,14 +34,14 @@ namespace Foam
 {
 namespace enhancementModels
 {
-    defineTypeNameAndDebug(pseudoFirstOrder, 0);
-    addToRunTimeSelectionTable(enhancementModel, pseudoFirstOrder, dictionary);
+    defineTypeNameAndDebug(surfaceRenewalPseudoFirstOrder, 0);
+    addToRunTimeSelectionTable(enhancementModel, surfaceRenewalPseudoFirstOrder, dictionary);
 }
 }
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
-Foam::enhancementModels::pseudoFirstOrder::pseudoFirstOrder
+Foam::enhancementModels::surfaceRenewalPseudoFirstOrder::surfaceRenewalPseudoFirstOrder
 (
     const dictionary& dict,
     const solvers::multicomponentFilm& film,
@@ -65,7 +65,7 @@ Foam::enhancementModels::pseudoFirstOrder::pseudoFirstOrder
 
 // * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * * //
 
-void Foam::enhancementModels::pseudoFirstOrder::update()
+void Foam::enhancementModels::surfaceRenewalPseudoFirstOrder::update()
 {
     //- Look up film-side mass transfer rate coefficient field
     const volScalarField& k_l = filmMesh_.lookupObject<volScalarField>("k");
@@ -85,7 +85,7 @@ void Foam::enhancementModels::pseudoFirstOrder::update()
 }
 
 
-bool Foam::enhancementModels::pseudoFirstOrder::read()
+bool Foam::enhancementModels::surfaceRenewalPseudoFirstOrder::read()
 {
     if (enhancementModel::read())
     {

--- a/src/enhancementModels/surfaceRenewalPseudoFirstOrder/surfaceRenewalPseudoFirstOrder.H
+++ b/src/enhancementModels/surfaceRenewalPseudoFirstOrder/surfaceRenewalPseudoFirstOrder.H
@@ -24,26 +24,28 @@ License
     along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
 
 Class
-    Foam::interphaseMassTransferModels::pseudoFirstOrder
+    Foam::interphaseMassTransferModels::surfaceRenewalPseudoFirstOrder
 
 Description
-    Enhancement factor according to the penetration model
+    Enhancement factor for a pseudo-first order irreversible
+    reaction based on the surface renewal theory
     where E = sqrt(1 + Ha^2). Model more appropriate for 
     3 < Ha < E_inf;
 
-    Reference:
-    Aronu, UE, Hartono, A., Hoff, K. A., & Svendsen, H. F. (2011). 
-    Kinetics of carbon dioxide absorption into aqueous amino acid salt: 
-    potassium salt of sarcosine solution. 
-    Industrial & engineering chemistry research , 50 (18), 10465-10475.
+    References
+    [1] Putta, K. R., Tobiesen, F. A., Svendsen, H. F., & Knuutila, H. K. (2017). 
+    Applicability of enhancement factor models for CO2 absorption into aqueous MEA solutions. 
+    Applied Energy, 206, 765-783.
+
+    [2] Danckwerts PV. Gas-liquid reactions. McGraw-Hill; 1970.
 
 SourceFiles
-    pseudoFirstOrder.C
+    surfaceRenewalPseudoFirstOrder.C
 
 \*---------------------------------------------------------------------------*/
 
-#ifndef pseudoFirstOrder_H
-#define pseudoFirstOrder_H
+#ifndef surfaceRenewalPseudoFirstOrder_H
+#define surfaceRenewalPseudoFirstOrder_H
 
 #include "enhancementModel.H"
 
@@ -55,10 +57,10 @@ namespace enhancementModels
 {
 
 /*---------------------------------------------------------------------------*\
-                                  Class pseudoFirstOrder
+                                  Class surfaceRenewalPseudoFirstOrder
 \*---------------------------------------------------------------------------*/
 
-class pseudoFirstOrder
+class surfaceRenewalPseudoFirstOrder
 :
     public enhancementModel
 {
@@ -76,13 +78,13 @@ class pseudoFirstOrder
 public:
 
     //- Runtime type information
-    TypeName("pseudoFirstOrder");
+    TypeName("surfaceRenewalPseudoFirstOrder");
 
 
     // Constructors
 
         //- Construct from components
-        pseudoFirstOrder
+        surfaceRenewalPseudoFirstOrder
         (
             const dictionary& dict,
             const solvers::multicomponentFilm& film,
@@ -91,7 +93,7 @@ public:
 
 
     //- Destructor
-    virtual ~pseudoFirstOrder()
+    virtual ~surfaceRenewalPseudoFirstOrder()
     {}
 
 


### PR DESCRIPTION
The previous enhancement factor named "pseudoFirstOrder" had its name changed in this PR to "surfaceRenewalPseudoFirstOrder" based on paper below:

References
    [1] Putta, K. R., Tobiesen, F. A., Svendsen, H. F., & Knuutila, H. K. (2017). 
    Applicability of enhancement factor models for CO2 absorption into aqueous MEA solutions. 
    Applied Energy, 206, 765-783.
