### PR TITLE
Enhancement factor for a pseudo 1st order reaction based on the film theory

### DIFF
--- a/src/enhancementModels/Make/files
+++ b/src/enhancementModels/Make/files
@@ -4,5 +4,6 @@ enhancementModel/enhancementModelNew.C
 noEnhancement/noEnhancement.C
 lowHa/lowHa.C
 surfaceRenewalPseudoFirstOrder/surfaceRenewalPseudoFirstOrder.C
+filmPseudoFirstOrder/filmPseudoFirstOrder.C
 
 LIB = $(FOAM_USER_LIBBIN)/libenhancementModels

--- a/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.C
+++ b/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.C
@@ -35,7 +35,8 @@ namespace Foam
 namespace enhancementModels
 {
     defineTypeNameAndDebug(filmPseudoFirstOrder, 0);
-    addToRunTimeSelectionTable(enhancementModel, filmPseudoFirstOrder, dictionary);
+    addToRunTimeSelectionTable(enhancementModel, filmPseudoFirstOrder, 
+		    dictionary);
 }
 }
 
@@ -56,7 +57,8 @@ Foam::enhancementModels::filmPseudoFirstOrder::filmPseudoFirstOrder
         filmSpecieID
     ),
     
-    D1_(dimArea/dimTime/dimTemperature, massTransferModelCoeffs_.lookup<scalar>("Dl1")),
+    D1_(dimArea/dimTime/dimTemperature, 
+		    massTransferModelCoeffs_.lookup<scalar>("Dl1")),
     D2_(dimArea/dimTime, massTransferModelCoeffs_.lookup<scalar>("Dl2")),
     tStart_(massTransferModelCoeffs_.lookupOrDefault<scalar>("tStart", 0.0))
 {
@@ -79,7 +81,8 @@ void Foam::enhancementModels::filmPseudoFirstOrder::update()
     //- Set E = Ha / tanh(Ha)
     if (filmMesh_.time().value() >= tStart_)
     {
-        const volScalarField Ha = Foam::sqrt(D * enhancementModel::kApp() / Foam::pow(klLim,2));
+        const volScalarField Ha = Foam::sqrt(D * enhancementModel::kApp()) 
+					/ klLim;
 
         E_ = Ha / Foam::tanh(Ha);
     }

--- a/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.C
+++ b/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.C
@@ -79,7 +79,7 @@ void Foam::enhancementModels::filmPseudoFirstOrder::update()
     //- Set E = Ha / tanh(Ha)
     if (filmMesh_.time().value() >= tStart_)
     {
-	const volScalarField Ha = (D * enhancementModel::kApp() / Foam::pow(klLim,2));
+        const volScalarField Ha = (D * enhancementModel::kApp() / Foam::pow(klLim,2));
 
         E_ = Ha / Foam::tanh(Ha);
     }

--- a/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.C
+++ b/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.C
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2022 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+                Copyright (C) 2023 Oak Ridge National Laboratory                
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "filmPseudoFirstOrder.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace enhancementModels
+{
+    defineTypeNameAndDebug(filmPseudoFirstOrder, 0);
+    addToRunTimeSelectionTable(enhancementModel, filmPseudoFirstOrder, dictionary);
+}
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::enhancementModels::filmPseudoFirstOrder::filmPseudoFirstOrder
+(
+    const dictionary& dict,
+    const solvers::multicomponentFilm& film,
+    const label& filmSpecieID
+)
+:
+    enhancementModel
+    (
+        typeName,
+        dict,
+        film,
+        filmSpecieID
+    ),
+    
+    D1_(dimArea/dimTime/dimTemperature, massTransferModelCoeffs_.lookup<scalar>("Dl1")),
+    D2_(dimArea/dimTime, massTransferModelCoeffs_.lookup<scalar>("Dl2")),
+    tStart_(massTransferModelCoeffs_.lookupOrDefault<scalar>("tStart", 0.0))
+{
+}
+
+
+// * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * * //
+
+void Foam::enhancementModels::filmPseudoFirstOrder::update()
+{
+    //- Look up film-side mass transfer rate coefficient field
+    const volScalarField& k_l = filmMesh_.lookupObject<volScalarField>("k");
+    const volScalarField& Tf = filmMesh_.lookupObject<volScalarField>("T");
+
+    const volScalarField klLim
+        = max(k_l, dimensionedScalar(dimVelocity, 1e-8));
+
+    const volScalarField D = (D1_ * Tf) + D2_;  
+
+    //- Set E = Ha / tanh(Ha)
+    if (filmMesh_.time().value() >= tStart_)
+    {
+	const volScalarField Ha = (D * enhancementModel::kApp() / Foam::pow(klLim,2));
+
+        E_ = Ha / Foam::tanh(Ha);
+    }
+}
+
+
+bool Foam::enhancementModels::filmPseudoFirstOrder::read()
+{
+    if (enhancementModel::read())
+    {
+        return true;
+    }
+    
+    else
+    {
+        return false;
+    }
+}
+
+// ************************************************************************* //

--- a/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.C
+++ b/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.C
@@ -79,7 +79,7 @@ void Foam::enhancementModels::filmPseudoFirstOrder::update()
     //- Set E = Ha / tanh(Ha)
     if (filmMesh_.time().value() >= tStart_)
     {
-        const volScalarField Ha = (D * enhancementModel::kApp() / Foam::pow(klLim,2));
+        const volScalarField Ha = Foam::sqrt(D * enhancementModel::kApp() / Foam::pow(klLim,2));
 
         E_ = Ha / Foam::tanh(Ha);
     }

--- a/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.H
+++ b/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.H
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2022 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+                Copyright (C) 2023 Oak Ridge National Laboratory                
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::interphaseMassTransferModels::filmPseudoFirstOrder
+
+Description
+    Enhancement factor for a pseudo-first order irreversible
+    reaction based on the film theory
+    where E = Ha / tanh(Ha). Model more appropriate for 
+    3 < Ha < E_inf;
+
+    References:
+    [1] Putta, K. R., Tobiesen, F. A., Svendsen, H. F., & Knuutila, H. K. (2017). 
+    Applicability of enhancement factor models for CO2 absorption into aqueous MEA solutions. 
+    Applied Energy, 206, 765-783.
+
+    [2] Hatta S. Technical reports. Tohoku Imp Univ; 1928. 8.
+
+SourceFiles
+    filmPseudoFirstOrder.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef filmPseudoFirstOrder_H
+#define filmPseudoFirstOrder_H
+
+#include "enhancementModel.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace enhancementModels
+{
+
+/*---------------------------------------------------------------------------*\
+                                  Class filmPseudoFirstOrder
+\*---------------------------------------------------------------------------*/
+
+class filmPseudoFirstOrder
+:
+    public enhancementModel
+{
+    // Private Data
+
+        //- 1st coefficient of Diffusivity of specie in liquid
+        const dimensionedScalar D1_;
+
+	//- 2nd coefficient of Diffusivity of specie in liquid
+        const dimensionedScalar D2_;
+
+        //- Time to turn enhancement on
+        const scalar tStart_;
+
+public:
+
+    //- Runtime type information
+    TypeName("filmPseudoFirstOrder");
+
+
+    // Constructors
+
+        //- Construct from components
+        filmPseudoFirstOrder
+        (
+            const dictionary& dict,
+            const solvers::multicomponentFilm& film,
+            const label& filmSpecieID
+        );
+
+
+    //- Destructor
+    virtual ~filmPseudoFirstOrder()
+    {}
+
+
+    // Member Functions
+    
+        //- Update mass transfer field
+        virtual void update();
+
+        //- Read the dictionary
+        virtual bool read();
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace interphaseMassTransferModels
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.H
+++ b/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.H
@@ -33,8 +33,10 @@ Description
     3 < Ha < E_inf;
 
     References:
-    [1] Putta, K. R., Tobiesen, F. A., Svendsen, H. F., & Knuutila, H. K. (2017). 
-    Applicability of enhancement factor models for CO2 absorption into aqueous MEA solutions. 
+    [1] Putta, K. R., Tobiesen, F. A., Svendsen, H. F., 
+    & Knuutila, H. K. (2017). 
+    Applicability of enhancement factor models for CO2 absorption into aqueous 
+    MEA solutions. 
     Applied Energy, 206, 765-783.
 
     [2] Hatta S. Technical reports. Tohoku Imp Univ; 1928. 8.

--- a/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.H
+++ b/src/enhancementModels/filmPseudoFirstOrder/filmPseudoFirstOrder.H
@@ -69,7 +69,7 @@ class filmPseudoFirstOrder
         //- 1st coefficient of Diffusivity of specie in liquid
         const dimensionedScalar D1_;
 
-	//- 2nd coefficient of Diffusivity of specie in liquid
+        //- 2nd coefficient of Diffusivity of specie in liquid
         const dimensionedScalar D2_;
 
         //- Time to turn enhancement on


### PR DESCRIPTION
An enhancement factor based on the film theory is added in this PR for a pseudo 1st order reaction as given in the work of:

Putta, K. R., Tobiesen, F. A., Svendsen, H. F., & Knuutila, H. K. (2017).
Applicability of enhancement factor models for CO2 absorption into aqueous MEA solutions.
Applied Energy, 206, 765-783.

The results are below computed using the same $k_g$ and $k_l$. It can be seen that they are basically the same. This is due to the form of the enhancement factor from the film theory. Since $Ha > 1$, $tanh(Ha)$ varies from 0 to 1.

| Enhancement factor | Capture efficiency (%) |
| ---------------------- | ------------------------ |
| $E=Ha$                    | 13.7632       |
| $E=\frac{Ha}{tanh(Ha)}$  | 13.7633       |