### PR TITLE
Enhancement factor based on penetration theory for a pseudo-first order reaction

### DIFF
--- a/src/enhancementModels/Make/files
+++ b/src/enhancementModels/Make/files
@@ -5,5 +5,6 @@ noEnhancement/noEnhancement.C
 lowHa/lowHa.C
 surfaceRenewalPseudoFirstOrder/surfaceRenewalPseudoFirstOrder.C
 filmPseudoFirstOrder/filmPseudoFirstOrder.C
+penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.C
 
 LIB = $(FOAM_USER_LIBBIN)/libenhancementModels

--- a/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.C
+++ b/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.C
@@ -81,10 +81,14 @@ void Foam::enhancementModels::penetrationPseudoFirstOrder::update()
     //- Set E = Ha[{1 + pi/8*Ha^2}*erf{sqrt(4*Ha^2/pi)} + exp(4*Ha^2/pi)/2*Ha]
     if (filmMesh_.time().value() >= tStart_)
     {
-        const volScalarField Ha = Foam::sqrt(D * enhancementModel::kApp() / Foam::pow(klLim,2));	    
+        const volScalarField Ha = Foam::sqrt(D * enhancementModel::kApp()) / klLim;	    
+
+	// this is to avoid that Foam::exp blows up due to very high values
+	volScalarField arg = Foam::min(Ha, 15.0);
+	//
 
         E_ = (1.0 + (pi/(8.0 * Foam::pow(Ha,2)))) * Foam::erf(Ha * Foam::pow(4.0/pi,0.5));
-        E_ += 0.5 * Foam::exp(4.0 * Foam::pow(Ha,2) / pi) / Ha;
+        E_ += 0.5 * Foam::exp(4.0 * Foam::pow(arg,2) / pi) / Ha;
         E_ *= Ha;
 
     }

--- a/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.C
+++ b/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.C
@@ -81,7 +81,7 @@ void Foam::enhancementModels::penetrationPseudoFirstOrder::update()
     //- Set E = Ha[{1 + pi/8*Ha^2}*erf{sqrt(4*Ha^2/pi)} + exp(4*Ha^2/pi)/2*Ha]
     if (filmMesh_.time().value() >= tStart_)
     {
-        const volScalarField Ha = (D * enhancementModel::kApp() / Foam::pow(klLim,2));	    
+        const volScalarField Ha = Foam::sqrt(D * enhancementModel::kApp() / Foam::pow(klLim,2));	    
 
         E_ = (1.0 + (pi/(8.0 * Foam::pow(Ha,2)))) * Foam::erf(Ha * Foam::pow(4.0/pi,0.5));
         E_ += 0.5 * Foam::exp(4.0 * Foam::pow(Ha,2) / pi) / Ha;

--- a/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.C
+++ b/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.C
@@ -84,8 +84,8 @@ void Foam::enhancementModels::penetrationPseudoFirstOrder::update()
         const volScalarField Ha = (D * enhancementModel::kApp() / Foam::pow(klLim,2));	    
 
         E_ = (1.0 + (pi/(8.0 * Foam::pow(Ha,2)))) * Foam::erf(Ha * Foam::pow(4.0/pi,0.5));
-	E_ += 0.5 * Foam::exp(4.0 * Foam::pow(Ha,2) / pi) / Ha;
-	E_ *= Ha;
+        E_ += 0.5 * Foam::exp(4.0 * Foam::pow(Ha,2) / pi) / Ha;
+        E_ *= Ha;
 
     }
 }

--- a/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.C
+++ b/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.C
@@ -81,14 +81,16 @@ void Foam::enhancementModels::penetrationPseudoFirstOrder::update()
     //- Set E = Ha[{1 + pi/8*Ha^2}*erf{sqrt(4*Ha^2/pi)} + exp(4*Ha^2/pi)/2*Ha]
     if (filmMesh_.time().value() >= tStart_)
     {
-        const volScalarField Ha = Foam::sqrt(D * enhancementModel::kApp()) / klLim;	    
+        const volScalarField Ha = Foam::sqrt(D * enhancementModel::kApp()) 
+		/ klLim;	    
 
-	// this is to avoid that Foam::exp blows up due to very high values
-	volScalarField arg = Foam::min(Ha, 15.0);
-	//
+        // this is to avoid that Foam::exp blows up due to very high values
+        volScalarField arg = Foam::min(Ha, 15.0);
+        //
 
-        E_ = (1.0 + (pi/(8.0 * Foam::pow(Ha,2)))) * Foam::erf(Ha * Foam::pow(4.0/pi,0.5));
-        E_ += 0.5 * Foam::exp(4.0 * Foam::pow(arg,2) / pi) / Ha;
+        E_ = (1.0 + (pi / (8.0 * Foam::pow(Ha, 2.0)))) 
+		* Foam::erf(Ha * Foam::pow(4.0 / pi, 0.5));
+        E_ += 0.5 * Foam::exp(4.0 * Foam::pow(arg, 2.0) / pi) / Ha;
         E_ *= Ha;
 
     }

--- a/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.H
+++ b/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.H
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2022 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+                Copyright (C) 2023 Oak Ridge National Laboratory                
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::interphaseMassTransferModels::penetrationPseudoFirstOrder
+
+Description
+    Enhancement factor according to the penetration model
+    where E = Ha[{1 + pi/8*Ha^2}*erf{sqrt(4*Ha^2/pi)} + exp(4*Ha^2/pi)/2*Ha]. 
+    Model more appropriate for 3 < Ha < E_inf;
+
+    References
+    [1] Putta, K. R., Tobiesen, F. A., Svendsen, H. F., & Knuutila, H. K. (2017). 
+    Applicability of enhancement factor models for CO2 absorption into aqueous MEA solutions. 
+    Applied Energy, 206, 765-783.
+
+    [2] Danckwerts PV. Gas-liquid reactions. McGraw-Hill; 1970.
+
+SourceFiles
+    penetrationPseudoFirstOrder.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef penetrationPseudoFirstOrder_H
+#define penetrationPseudoFirstOrder_H
+
+#include "enhancementModel.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace enhancementModels
+{
+
+/*---------------------------------------------------------------------------*\
+                                  Class penetrationPseudoFirstOrder
+\*---------------------------------------------------------------------------*/
+
+class penetrationPseudoFirstOrder
+:
+    public enhancementModel
+{
+    // Private Data
+
+        //- 1st coefficient of Diffusivity of specie in liquid
+        const dimensionedScalar D1_;
+
+	//- 2nd coefficient of Diffusivity of specie in liquid
+        const dimensionedScalar D2_;
+
+        //- Time to turn enhancement on
+        const scalar tStart_;
+
+public:
+
+    //- Runtime type information
+    TypeName("penetrationPseudoFirstOrder");
+
+
+    // Constructors
+
+        //- Construct from components
+        penetrationPseudoFirstOrder
+        (
+            const dictionary& dict,
+            const solvers::multicomponentFilm& film,
+            const label& filmSpecieID
+        );
+
+
+    //- Destructor
+    virtual ~penetrationPseudoFirstOrder()
+    {}
+
+
+    // Member Functions
+    
+        //- Update mass transfer field
+        virtual void update();
+
+        //- Read the dictionary
+        virtual bool read();
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace interphaseMassTransferModels
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.H
+++ b/src/enhancementModels/penetrationPseudoFirstOrder/penetrationPseudoFirstOrder.H
@@ -31,6 +31,9 @@ Description
     where E = Ha[{1 + pi/8*Ha^2}*erf{sqrt(4*Ha^2/pi)} + exp(4*Ha^2/pi)/2*Ha]. 
     Model more appropriate for 3 < Ha < E_inf;
 
+    NOTE: The value of Ha inside the exponential function is capped at 15.
+          This is to avoid that funtion blowing up. 
+
     References
     [1] Putta, K. R., Tobiesen, F. A., Svendsen, H. F., & Knuutila, H. K. (2017). 
     Applicability of enhancement factor models for CO2 absorption into aqueous MEA solutions. 


### PR DESCRIPTION
The enhancement factor based on the penetration theory for a pseudo 1st order reaction us added in this PR. The equation is given in:

[1] Putta, K. R., Tobiesen, F. A., Svendsen, H. F., & Knuutila, H. K. (2017).
    Applicability of enhancement factor models for CO2 absorption into aqueous MEA solutions.
    Applied Energy, 206, 765-783.

[2] Danckwerts PV. Gas-liquid reactions. McGraw-Hill; 1970.

| Enhancement factor | Capture efficiency (%) |
| ---------------------- | ------------------------ |
| $E=Ha$                    | 13.7632       |
| Penetration_theory  | 14.5219       |